### PR TITLE
Fill FFT range domain plot

### DIFF
--- a/FFTWidget.cpp
+++ b/FFTWidget.cpp
@@ -209,10 +209,11 @@ void FFTWidget::drawSpectrum(QPainter& painter)
 {
     if (m_magnitudeSpectrum.empty() || m_rangeAxis.empty()) return;
 
-    painter.setPen(QPen(QColor(0, 255, 255), 2));
-    painter.setBrush(Qt::NoBrush);
-
+    // Create filled area similar to the reference image
     QPolygonF spectrum;
+    
+    // Start from bottom-left corner of the plot area
+    spectrum << QPointF(m_plotRect.left(), m_plotRect.bottom());
 
     for (size_t i = 0; i < m_magnitudeSpectrum.size(); ++i) {
         float range = m_rangeAxis[i];
@@ -229,9 +230,23 @@ void FFTWidget::drawSpectrum(QPainter& painter)
 
         spectrum << QPointF(x, y);
     }
+    
+    // Close the polygon by adding bottom-right corner
+    if (!spectrum.isEmpty()) {
+        QPointF lastPoint = spectrum.last();
+        spectrum << QPointF(lastPoint.x(), m_plotRect.bottom());
+    }
 
-    if (spectrum.size() > 1) {
-        painter.drawPolyline(spectrum);
+    if (spectrum.size() > 2) {
+        // Set up brush for filled area with blue color similar to reference image
+        QColor fillColor(70, 150, 200, 180); // Semi-transparent blue
+        painter.setBrush(QBrush(fillColor));
+        
+        // Set pen for outline
+        painter.setPen(QPen(QColor(0, 120, 180), 2));
+        
+        // Draw filled polygon
+        painter.drawPolygon(spectrum);
     }
 }
 


### PR DESCRIPTION
Fill the FFT Range domain plot with a semi-transparent blue color to match the requested visual style.

---
<a href="https://cursor.com/background-agent?bcId=bc-72c2a2f4-208e-4e6e-96a3-7aecb0c9f47f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-72c2a2f4-208e-4e6e-96a3-7aecb0c9f47f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

